### PR TITLE
Update spray.el to catch runaway timer

### DIFF
--- a/spray.el
+++ b/spray.el
@@ -276,8 +276,8 @@ decreasing by one for each subsequent word."
          (setq spray--initial-delay (1- spray--initial-delay)))
         ((not (zerop spray--delay))
          (setq spray--delay (1- spray--delay)))
-        ((string-match "timer-list-mode" (symbol-name major-mode))
-         nil)
+        ((not (eq (current-buffer) spray--initial-buffer))
+         (spray-quit))
         (t
          (widen)
          (if (eobp)
@@ -308,6 +308,7 @@ Returns t if spray was unpaused."
   "Start / resume spray."
   (interactive)
   (setq spray--first-words spray-ramp)
+  (setq spray--initial-buffer (current-buffer))
   (setq spray--running
         (run-with-timer 0 (/ 60.0 spray-wpm) 'spray--update)))
 

--- a/spray.el
+++ b/spray.el
@@ -276,6 +276,8 @@ decreasing by one for each subsequent word."
          (setq spray--initial-delay (1- spray--initial-delay)))
         ((not (zerop spray--delay))
          (setq spray--delay (1- spray--delay)))
+        ((string-match "timer-list-mode" (symbol-name major-mode))
+         nil)
         (t
          (widen)
          (if (eobp)


### PR DESCRIPTION
Prevent spray--update from spraying in list-timers. If the timer gets stuck it is very difficult to stop without this.

I understand this is a mirror, but the upstream is 404'd. Please advise.

Thanks for your interest in contributing to this package.

This repository is only a mirror.

⚠️ Please do not open a pull-request here! ⚠️ 

🆘 Visit https://emacsmirror.net/stats/upstreams.html to lookup the homepage or upstream repository of this package.

(If you are opening a pull-request at https://github.com/emacsattic/.github, then please disregard the above.  It does not apply in that case, but for technical reasons I cannot prevent it from being shown to you anyway.)

